### PR TITLE
Disable automatic text trim on search

### DIFF
--- a/app/templates/main/manage_users.html
+++ b/app/templates/main/manage_users.html
@@ -19,6 +19,7 @@
                                style="border-collapse:collapse"
                                data-toggle="table"
                                data-search="true"
+                               data-trim-on-search="false"
                                data-show-refresh="true"
                                data-show-toggle="true"
                                data-show-columns="true"

--- a/app/templates/request/requests.html
+++ b/app/templates/request/requests.html
@@ -23,6 +23,7 @@
                                style="border-collapse:collapse"
                                data-toggle="table"
                                data-search="true"
+                               data-trim-on-search="false"
                                data-show-refresh="true"
                                data-show-toggle="true"
                                data-show-columns="true"

--- a/app/templates/vendor/vendors.html
+++ b/app/templates/vendor/vendors.html
@@ -23,6 +23,7 @@
                                style="border-collapse:collapse"
                                data-toggle="table"
                                data-search="true"
+                               data-trim-on-search="false"
                                data-show-refresh="true"
                                data-show-toggle="true"
                                data-show-columns="true"


### PR DESCRIPTION
This PR:

- Disables automatic whitespace trimming in table searches by adding data-trim-on-search="false".